### PR TITLE
Make sure we return a string instead of bytes.

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -261,7 +261,7 @@ dynamic toDart(ASN1Object obj) {
     case 0x86:
       return utf8.decode(obj.valueBytes());
   }
-  return obj.valueBytes();
+  return utf8.decode(obj.valueBytes());
   throw ArgumentError(
       'Cannot convert $obj (${obj.runtimeType}) to dart object.');
 }


### PR DESCRIPTION
Updated to make sure we can parse: https://github.com/eu-digital-green-certificates/dgc-testdata/issues/325